### PR TITLE
fix backupmeta `Invalid data length` complained by thrift and a little refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 *.exe
 *.out
 *.app
+bin/*

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -21,6 +21,7 @@ func NewRestoreCMD() *cobra.Command {
 	restoreCmd.PersistentFlags().StringVar(&restoreConfig.BackendUrl, "storage", "", "storage path")
 	restoreCmd.PersistentFlags().StringVar(&restoreConfig.User, "user", "", "user for meta and storage")
 	restoreCmd.PersistentFlags().StringVar(&restoreConfig.BackupName, "name", "", "backup name")
+	restoreCmd.PersistentFlags().BoolVar(&restoreConfig.AllowStandaloneMeta, "allow_standalone_meta", false, "if the target cluster with standalone meta service is allowed(for testing purpose)")
 	restoreCmd.PersistentFlags().IntVar(&restoreConfig.MaxConcurrent, "concurrent", 5, "max concurrent(for aliyun OSS)")
 	restoreCmd.PersistentFlags().StringVar(&restoreConfig.CommandArgs, "extra_args", "", "storage utils(oss/hdfs/s3) args for restore")
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,11 +19,12 @@ type BackupConfig struct {
 }
 
 type RestoreConfig struct {
-	Meta              string
-	BackendUrl        string
-	MaxSSHConnections int
-	User              string
-	BackupName        string
+	Meta                string
+	BackendUrl          string
+	MaxSSHConnections   int
+	User                string
+	BackupName          string
+	AllowStandaloneMeta bool
 	// Only for OSS for now
 	MaxConcurrent int
 	CommandArgs   string

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -445,7 +445,10 @@ func (r *Restore) getMetaInfo(hosts []*nebula.HostAddr) ([]config.NodeInfo, erro
 	var info []config.NodeInfo
 
 	if len(hosts) == 0 {
-		return nil, listClusterFailed
+		r.log.Warn("meta host list is nil")
+		if !r.config.AllowStandaloneMeta {
+			return nil, listClusterFailed
+		}
 	}
 
 	for _, v := range hosts {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,65 @@
+package utils
+
+import (
+	"os"
+
+	"github.com/facebook/fbthrift/thrift/lib/go/thrift"
+	"github.com/vesoft-inc/nebula-go/v2/nebula/meta"
+	"go.uber.org/zap"
+)
+
+func PutMetaToFile(logger *zap.Logger, meta *meta.BackupMeta, filename string) error {
+	file, err := os.OpenFile(filename, os.O_TRUNC|os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		logger.Error("store backupmeta failed in open file",
+			zap.String("filename", filename),
+			zap.String("error", err.Error()))
+		return err
+	}
+	defer file.Close()
+
+	trans := thrift.NewStreamTransport(file, file)
+	defer trans.Close()
+
+	transF := thrift.NewFramedTransport(trans)
+	defer transF.Close()
+
+	binaryOut := thrift.NewBinaryProtocol(transF, false, true)
+
+	err = meta.Write(binaryOut)
+	if err != nil {
+		logger.Error("store backupmeta failed in write",
+			zap.String("filename", filename),
+			zap.String("error", err.Error()))
+		return err
+	}
+
+	binaryOut.Flush()
+	return nil
+}
+
+func GetMetaFromFile(logger *zap.Logger, filename string) (*meta.BackupMeta, error) {
+	file, err := os.OpenFile(filename, os.O_RDONLY, 0644)
+	if err != nil {
+		logger.Error("get backupmeta failed in open file",
+			zap.String("filename", filename),
+			zap.String("error", err.Error()))
+		return nil, err
+	}
+	defer file.Close()
+
+	trans := thrift.NewStreamTransport(file, file)
+	defer trans.Close()
+
+	transF := thrift.NewFramedTransport(trans)
+	defer transF.Close()
+
+	binaryIn := thrift.NewBinaryProtocol(transF, false, true)
+	m := meta.NewBackupMeta()
+	err = m.Read(binaryIn)
+	if err != nil {
+		logger.Error("get backupmeta failed in read", zap.String("filename", filename), zap.String("error", err.Error()))
+		return nil, err
+	}
+	return m, nil
+}


### PR DESCRIPTION
this pr includes:
- fix `Invalid data length` complained by fbthrift.
- extract put/get backupmeta to a common function.
- add an option for allowing standalone meta service in restore cmd for testing scenes.