### PR TITLE
refine meta backup and restore process of local storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,16 @@ PKG := ./pkg/...
 BUILDTARGET := bin/br
 SUFFIX := $(GOEXE)
 
+GITSHA := $(shell git describe --no-match --always --dirty)
+GITREF := $(shell git rev-parse --abbrev-ref HEAD)
+
+REPO := github.com/vesoft-inc/nebula-br
+
+LDFLAGS += -X $(REPO)/pkg/version.GitSha=$(GITSHA)
+LDFLAGS += -X $(REPO)/pkg/version.GitRef=$(GITREF)
+
 build:
-	$(GO) build -o $(BUILDTARGET) main.go
+	$(GO) build -ldflags '$(LDFLAGS)' -o $(BUILDTARGET) main.go
 
 test:
 	$(GO) test -v $(PKG) -short

--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -18,9 +18,21 @@ func NewBackupCmd() *cobra.Command {
 
 	backupCmd.AddCommand(newFullBackupCmd())
 	backupCmd.PersistentFlags().StringVar(&backupConfig.Meta, "meta", "", "meta server")
-	backupCmd.PersistentFlags().StringArrayVar(&backupConfig.SpaceNames, "spaces", nil, "space names")
-	backupCmd.PersistentFlags().StringVar(&backupConfig.BackendUrl, "storage", "", "storage path")
-	backupCmd.PersistentFlags().StringVar(&backupConfig.User, "user", "", "user for meta/storage")
+	backupCmd.PersistentFlags().StringArrayVar(&backupConfig.SpaceNames, "spaces", nil,
+		`(EXPERIMENTAL)space names.
+    By this option, user can specify which spaces to backup. Now this feature is still experimental.
+    `)
+	backupCmd.PersistentFlags().StringVar(&backupConfig.BackendUrl, "storage", "",
+		`backup target url, format: <SCHEME>://<PATH>.
+    <SCHEME>: a string indicating which backend type. optional: local, hdfs.
+    now hdfs and local is supported, s3 and oss are still experimental.
+    example:
+    for local - "local:///the/local/path/to/backup"
+    for hdfs  - "hdfs://example_host:example_port/examplepath"
+    (EXPERIMENTAL) for oss - "oss://example/url/to/the/backup"
+    (EXPERIMENTAL) for s3  - "s3://example/url/to/the/backup"
+    `)
+	backupCmd.PersistentFlags().StringVar(&backupConfig.User, "user", "", "username to login into the hosts where meta/storage service located")
 	backupCmd.PersistentFlags().IntVar(&backupConfig.MaxSSHConnections, "connection", 5, "max ssh connection")
 	backupCmd.PersistentFlags().IntVar(&backupConfig.MaxConcurrent, "concurrent", 5, "max concurrent(for aliyun OSS)")
 	backupCmd.PersistentFlags().StringVar(&backupConfig.CommandArgs, "extra_args", "", "backup storage utils(oss/hdfs/s3) args for backup")

--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -10,7 +10,7 @@ import (
 func NewCleanupCmd() *cobra.Command {
 	cleanupCmd := &cobra.Command{
 		Use:          "cleanup",
-		Short:        "Clean up temporary files in backup",
+		Short:        "[EXPERIMENTAL]Clean up temporary files in backup",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logger, _ := log.NewLogger(config.LogPath)

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -21,7 +21,6 @@ func NewRestoreCMD() *cobra.Command {
 	restoreCmd.PersistentFlags().StringVar(&restoreConfig.BackendUrl, "storage", "", "storage path")
 	restoreCmd.PersistentFlags().StringVar(&restoreConfig.User, "user", "", "user for meta and storage")
 	restoreCmd.PersistentFlags().StringVar(&restoreConfig.BackupName, "name", "", "backup name")
-	restoreCmd.PersistentFlags().BoolVar(&restoreConfig.AllowStandaloneMeta, "allow_standalone_meta", false, "if the target cluster with standalone meta service is allowed(for testing purpose)")
 	restoreCmd.PersistentFlags().IntVar(&restoreConfig.MaxConcurrent, "concurrent", 5, "max concurrent(for aliyun OSS)")
 	restoreCmd.PersistentFlags().StringVar(&restoreConfig.CommandArgs, "extra_args", "", "storage utils(oss/hdfs/s3) args for restore")
 

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -55,7 +55,12 @@ func newFullRestoreCmd() *cobra.Command {
 
 			defer logger.Sync() // flushes buffer, if any
 
-			r := restore.NewRestore(restoreConfig, logger.Logger)
+			var r *restore.Restore
+			r, err = restore.NewRestore(restoreConfig, logger.Logger)
+			if err != nil {
+				return err
+			}
+
 			err = r.RestoreCluster()
 			if err != nil {
 				return err

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -4,16 +4,21 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/vesoft-inc/nebula-br/pkg/version"
 )
-
-var version string = "2.0"
 
 func NewVersionCmd() *cobra.Command {
 	versionCmd := &cobra.Command{
 		Use:   "version",
-		Short: "print the version of nebula br",
+		Short: "print the version of nebula br tool",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Println(version)
+			vstring := fmt.Sprintf(
+				`%s,V-%d.%d.%d
+   GitSha: %s
+   GitRef: %s
+please run "help" subcommand for more infomation.`, version.VerName, version.VerMajor, version.VerMinor, version.VerPatch, version.GitSha, version.GitRef)
+
+			fmt.Println(vstring)
 			return nil
 		},
 	}

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -306,10 +306,12 @@ func (b *Backup) uploadAll(meta *meta.BackupMeta) error {
 		return err
 	}
 
-	err = b.execPreUploadMetaCommand(b.backendStorage.BackupMetaDir())
-	if err != nil {
-		b.log.Error("exec pre uploadmeta command failed", zap.Error(err))
-		return err
+	if b.backendStorage.Scheme() == storage.SCHEME_LOCAL { // NB: only local backend need this
+		err = b.execPreUploadMetaCommand(b.backendStorage.BackupMetaDir())
+		if err != nil {
+			b.log.Error("exec pre uploadmeta command failed", zap.Error(err))
+			return err
+		}
 	}
 
 	var metaFiles []string

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -17,7 +17,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/vesoft-inc/nebula-br/pkg/config"
-	ctx0 "github.com/vesoft-inc/nebula-br/pkg/context"
+	backupCtx "github.com/vesoft-inc/nebula-br/pkg/context"
 	"github.com/vesoft-inc/nebula-br/pkg/metaclient"
 	"github.com/vesoft-inc/nebula-br/pkg/remote"
 	"github.com/vesoft-inc/nebula-br/pkg/storage"
@@ -59,7 +59,7 @@ type Backup struct {
 	metaFileName   string
 	storageMap     map[string]idPathMap
 	metaMap        map[string]idPathMap
-	storeCtx       *ctx0.Context
+	storeCtx       *backupCtx.Context
 }
 
 func NewBackupClient(cf config.BackupConfig, log *zap.Logger) (*Backup, error) {
@@ -70,7 +70,7 @@ func NewBackupClient(cf config.BackupConfig, log *zap.Logger) (*Backup, error) {
 	}
 	log.Info("local address", zap.String("address", local_addr))
 	var (
-		storeCtx ctx0.Context
+		storeCtx backupCtx.Context
 		backend  storage.ExternalStorage
 	)
 	backend, err = storage.NewExternalStorage(cf.BackendUrl, log, cf.MaxConcurrent, cf.CommandArgs,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,6 +16,7 @@ type BackupConfig struct {
 	// Only for OSS for now
 	MaxConcurrent int
 	CommandArgs   string
+	Verbose       bool
 }
 
 type RestoreConfig struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,12 +20,11 @@ type BackupConfig struct {
 }
 
 type RestoreConfig struct {
-	Meta                string
-	BackendUrl          string
-	MaxSSHConnections   int
-	User                string
-	BackupName          string
-	AllowStandaloneMeta bool
+	Meta              string
+	BackendUrl        string
+	MaxSSHConnections int
+	User              string
+	BackupName        string
 	// Only for OSS for now
 	MaxConcurrent int
 	CommandArgs   string

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -1,0 +1,21 @@
+package context
+
+import (
+	_ "github.com/vesoft-inc/nebula-go/v2/nebula"
+)
+
+type BackendUploadTracker interface {
+	StorageUploadingReport(spaceid string, host string, paths []string, desturl string)
+	MetaUploadingReport(host string, paths []string, desturl string)
+}
+
+// NB - not thread-safe
+type Context struct {
+	LocalAddr  string // the address of br client
+	RemoteAddr string // the address of nebula service
+	Reporter   BackendUploadTracker
+}
+
+func NewContext(localaddr string, r BackendUploadTracker) *Context {
+	return &Context{LocalAddr: localaddr, Reporter: r}
+}

--- a/pkg/metaclient/util.go
+++ b/pkg/metaclient/util.go
@@ -1,11 +1,29 @@
 package metaclient
 
 import (
+	"encoding/json"
 	"strconv"
 
 	"github.com/vesoft-inc/nebula-go/v2/nebula"
+	"github.com/vesoft-inc/nebula-go/v2/nebula/meta"
 )
 
 func HostaddrToString(host *nebula.HostAddr) string {
 	return host.Host + ":" + strconv.Itoa(int(host.Port))
+}
+
+func BackupMetaToString(m *meta.BackupMeta) string {
+	mstr, err := json.Marshal(m)
+	if err != nil {
+		return ""
+	}
+	return string(mstr)
+}
+
+func ListClusterInfoRespToString(m *meta.ListClusterInfoResp) string {
+	mstr, err := json.Marshal(m)
+	if err != nil {
+		return ""
+	}
+	return string(mstr)
 }

--- a/pkg/remote/ssh.go
+++ b/pkg/remote/ssh.go
@@ -71,6 +71,14 @@ func NewClientPool(addr string, user string, log *zap.Logger, count int) ([]*Cli
 	return clients, nil
 }
 
+func GetAddresstoReachRemote(addr string, user string, log *zap.Logger) (string, error) {
+	if cli, err := NewClient(addr, user, log); err == nil {
+		return strings.Split(cli.client.Conn.LocalAddr().String(), ":")[0], nil
+	} else {
+		return "", err
+	}
+}
+
 func (c *Client) Close() {
 	c.client.Close()
 }

--- a/pkg/remote/ssh_test.go
+++ b/pkg/remote/ssh_test.go
@@ -1,0 +1,43 @@
+package remote
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	_ "golang.org/x/crypto/ssh"
+)
+
+var remoteAddr = flag.String("addr", "", "remote ssh addr for test")
+var remoteUser = flag.String("user", "", "remote user for test")
+
+func TestClient(t *testing.T) {
+	ast := assert.New(t)
+	if *remoteAddr == "" || *remoteUser == "" {
+		t.Log("addr and user should be provided!")
+		return
+	}
+
+	logger, _ := zap.NewProduction()
+	cli, err := NewClient(*remoteAddr, *remoteUser, logger)
+	ast.Nil(err)
+
+	t.Logf("ssh user: %s", cli.client.Conn.User())
+	t.Logf("local addr: %s, remote addr: %s",
+		cli.client.Conn.LocalAddr().String(),
+		cli.client.Conn.RemoteAddr().String())
+}
+
+func TestGetLocalAddress(t *testing.T) {
+	ast := assert.New(t)
+	if *remoteAddr == "" || *remoteUser == "" {
+		t.Log("addr and user should be provided!")
+		return
+	}
+	logger, _ := zap.NewProduction()
+	laddr, err := GetAddresstoReachRemote(*remoteAddr, *remoteUser, logger)
+	ast.Nil(err)
+
+	t.Logf("local addr: %s", laddr)
+}

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -468,9 +468,7 @@ func (r *Restore) getMetaInfo(hosts []*nebula.HostAddr) ([]config.NodeInfo, erro
 
 	if len(hosts) == 0 {
 		r.log.Warn("meta host list is nil")
-		if !r.config.AllowStandaloneMeta {
-			return nil, listClusterFailed
-		}
+		return nil, listClusterFailed
 	}
 
 	for _, v := range hosts {

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -14,7 +14,7 @@ import (
 	_ "github.com/facebook/fbthrift/thrift/lib/go/thrift"
 	"github.com/scylladb/go-set/strset"
 	"github.com/vesoft-inc/nebula-br/pkg/config"
-	ctx0 "github.com/vesoft-inc/nebula-br/pkg/context"
+	backupCtx "github.com/vesoft-inc/nebula-br/pkg/context"
 	"github.com/vesoft-inc/nebula-br/pkg/metaclient"
 	"github.com/vesoft-inc/nebula-br/pkg/remote"
 	"github.com/vesoft-inc/nebula-br/pkg/storage"
@@ -36,7 +36,7 @@ type Restore struct {
 	storageNodes []config.NodeInfo
 	metaNodes    []config.NodeInfo
 	metaFileName string
-	ctx          *ctx0.Context
+	ctx          *backupCtx.Context
 }
 
 type spaceInfo struct {
@@ -59,7 +59,7 @@ func NewRestore(config config.RestoreConfig, log *zap.Logger) (*Restore, error) 
 	}
 
 	log.Info("local address", zap.String("address", local_addr))
-	ctx := ctx0.NewContext(local_addr, nil)
+	ctx := backupCtx.NewContext(local_addr, nil)
 
 	backend, err := storage.NewExternalStorage(config.BackendUrl, log, config.MaxConcurrent, config.CommandArgs, ctx)
 	if err != nil {

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -292,6 +292,10 @@ func (r *Restore) restoreMeta(sstFiles map[string][][]byte, storageIDMap map[str
 }
 
 func remoteCommandConcurrentRunner(g *errgroup.Group, addr string, user string, cmd string, log *zap.Logger) {
+	if cmd == "" {
+		log.Warn("cmd is empty", zap.Stack("empty cmd stack trace"))
+		return
+	}
 	runner := func() error {
 		client, err := remote.NewClient(addr, user, log)
 		if err != nil {

--- a/pkg/show/show.go
+++ b/pkg/show/show.go
@@ -31,7 +31,7 @@ type showInfo struct {
 var tableHeader []string = []string{"name", "create_time", "spaces", "full_backup", "specify_space"}
 
 func NewShow(backendUrl string, log *zap.Logger) *Show {
-	backend, err := storage.NewExternalStorage(backendUrl, log, 5, "")
+	backend, err := storage.NewExternalStorage(backendUrl, log, 5, "", nil)
 	if err != nil {
 		log.Error("new external storage failed", zap.Error(err))
 		return nil

--- a/pkg/storage/cmds.go
+++ b/pkg/storage/cmds.go
@@ -1,0 +1,41 @@
+package storage
+
+import (
+	"fmt"
+	"time"
+)
+
+func GetBackupDirSuffix() string {
+	return fmt.Sprintf("_old_%d", time.Now().Unix())
+}
+
+func getBackDir(origin string) string {
+	return origin + GetBackupDirSuffix()
+}
+
+func mvDirCommand(from string, to string) string {
+	if from != "" && to != "" {
+		return fmt.Sprintf("mv %s %s", from, to)
+	}
+	return ""
+}
+
+func rmDirCommand(dst string) string {
+	if dst != "" {
+		return fmt.Sprintf("rm -r %s 2>/dev/null", dst)
+	}
+	return ""
+}
+
+func mkDirCommand(dst string) string {
+	if dst != "" {
+		return fmt.Sprintf("mkdir -p %s", dst)
+	}
+	return ""
+}
+
+func mvAndMkDirCommand(srcDir string, bkDir string) string {
+	mvCmd := mvDirCommand(srcDir, bkDir)
+	mkCmd := mkDirCommand(srcDir)
+	return fmt.Sprintf("%s && %s", mvCmd, mkCmd)
+}

--- a/pkg/storage/cmds.go
+++ b/pkg/storage/cmds.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"regexp"
 	"time"
 )
 
@@ -20,8 +21,23 @@ func mvDirCommand(from string, to string) string {
 	return ""
 }
 
+var invalidDstRegex = `(^/+$)|(\s+)`
+var allowedDstRegex = `\S+_old_[0-9]+$`
+
+func sanityCheckForRM(dst string) bool {
+	invalid, _ := regexp.Compile(invalidDstRegex)
+	if invalid.MatchString(dst) {
+		return false
+	}
+	allowed, _ := regexp.Compile(allowedDstRegex)
+	if !allowed.MatchString(dst) {
+		return false
+	}
+	return true
+}
+
 func rmDirCommand(dst string) string {
-	if dst != "" {
+	if dst != "" && sanityCheckForRM(dst) {
 		return fmt.Sprintf("rm -r %s 2>/dev/null", dst)
 	}
 	return ""

--- a/pkg/storage/hdfs.go
+++ b/pkg/storage/hdfs.go
@@ -123,14 +123,20 @@ func (s HDFSBackedStore) RestoreStorageCommand(host string, spaceID []string, ds
 	return cmd
 }
 
-func (s HDFSBackedStore) RestoreMetaPreCommand(dst string) string {
-	//cleanup meta
-	return "rm -rf " + dst + " && mkdir -p " + dst
+func (s HDFSBackedStore) RestoreMetaPreCommand(srcDir string, bkDir string) string {
+	return mvAndMkDirCommand(srcDir, bkDir)
 }
 
-func (s HDFSBackedStore) RestoreStoragePreCommand(dst string) string {
-	//cleanup storage
-	return "rm -rf " + dst + " && mkdir -p " + dst
+func (s HDFSBackedStore) RestoreStoragePreCommand(srcDir string, bkDir string) string {
+	return mvAndMkDirCommand(srcDir, bkDir)
+}
+
+func (s HDFSBackedStore) RestoreMetaPostCommand(bkDir string) string {
+	return rmDirCommand(bkDir)
+}
+
+func (s HDFSBackedStore) RestoreStoragePostCommand(bkDir string) string {
+	return rmDirCommand(bkDir)
 }
 
 func (s HDFSBackedStore) CheckCommand() string {

--- a/pkg/storage/hdfs.go
+++ b/pkg/storage/hdfs.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/vesoft-inc/nebula-br/pkg/context"
 	"go.uber.org/zap"
 )
 
@@ -18,11 +19,7 @@ type HDFSBackedStore struct {
 	command    string
 }
 
-func NewHDFSBackendStore(url string, log *zap.Logger, maxConcurrent int, args string) *HDFSBackedStore {
-	return &HDFSBackedStore{url: url, log: log, args: args}
-}
-
-func NewHDFSBackedStore(url string, log *zap.Logger, maxConcurrent int, args string) *HDFSBackedStore {
+func NewHDFSBackendStore(url string, log *zap.Logger, maxConcurrent int, args string, ctx *context.Context) *HDFSBackedStore {
 	return &HDFSBackedStore{url: url, log: log, args: args}
 }
 
@@ -36,6 +33,9 @@ func (s *HDFSBackedStore) SetBackupName(name string) {
 
 func (s HDFSBackedStore) URI() string {
 	return s.url
+}
+func (s HDFSBackedStore) Scheme() string {
+	return SCHEME_HDFS
 }
 
 func (s HDFSBackedStore) copyCommand(src []string, dir string) string {
@@ -55,6 +55,10 @@ func (s *HDFSBackedStore) BackupPreCommand() []string {
 func (s HDFSBackedStore) BackupMetaCommand(src []string) string {
 	metaDir := s.url + "/" + "meta"
 	return s.copyCommand(src, metaDir)
+}
+
+func (s HDFSBackedStore) BackupMetaDir() string {
+	return s.url + "/" + "meta"
 }
 
 func (s HDFSBackedStore) BackupStorageCommand(src []string, host string, spaceId string) []string {

--- a/pkg/storage/local.go
+++ b/pkg/storage/local.go
@@ -166,14 +166,21 @@ func (s LocalBackedStore) RestoreStorageCommand(host string, spaceID []string, d
 	return cmd
 }
 
-func (s LocalBackedStore) RestoreMetaPreCommand(dst string) string {
-	//cleanup meta
-	return "rm -rf " + dst + " && mkdir -p " + dst
+func (s LocalBackedStore) RestoreMetaPreCommand(srcDir string, bkDir string) string {
+	// move to a backup path in case of error
+	return mvAndMkDirCommand(srcDir, bkDir)
 }
 
-func (s LocalBackedStore) RestoreStoragePreCommand(dst string) string {
-	//cleanup storage
-	return "rm -rf " + dst + " && mkdir -p " + dst
+func (s LocalBackedStore) RestoreStoragePreCommand(srcDir string, bkDir string) string {
+	return mvAndMkDirCommand(srcDir, bkDir)
+}
+
+func (s LocalBackedStore) RestoreMetaPostCommand(bkDir string) string {
+	return rmDirCommand(bkDir)
+}
+
+func (s LocalBackedStore) RestoreStoragePostCommand(bkDir string) string {
+	return rmDirCommand(bkDir)
 }
 
 func (s LocalBackedStore) CheckCommand() string {

--- a/pkg/storage/local.go
+++ b/pkg/storage/local.go
@@ -132,19 +132,6 @@ func (s LocalBackedStore) RestoreMetaFileCommand(file string, dst string) []stri
 	return args
 }
 
-func (s LocalBackedStore) restoreMetaCommandFromLocal(src []string, dst string) (string, []string) {
-	metaDir := s.BackupMetaDir()
-	files := ""
-	var sstFiles []string
-	for _, f := range src {
-		file := metaDir + "/" + f
-		files += file + " "
-		dstFile := dst + "/" + f
-		sstFiles = append(sstFiles, dstFile)
-	}
-	return fmt.Sprintf("cp -rf %s %s %s", files, s.args, dst), sstFiles
-}
-
 func (s LocalBackedStore) restoreMetaCommandFromRemote(src []string, dst string) (string, []string) {
 	metaDir := s.BackupMetaDir()
 	files := ""

--- a/pkg/storage/oss.go
+++ b/pkg/storage/oss.go
@@ -21,6 +21,11 @@ type OSSBackedStore struct {
 }
 
 func NewOSSBackendStore(url string, log *zap.Logger, maxConcurrent int, args string, ctx *context.Context) *OSSBackedStore {
+	if !strings.HasSuffix(url, "/") {
+		newUrl := url + "/"
+		log.Warn("original oss url not end with '/'", zap.String("origin-url", url), zap.String("new-url", newUrl))
+		url = newUrl
+	}
 	return &OSSBackedStore{url: url, log: log, maxConcurrent: strconv.Itoa(maxConcurrent), args: args}
 }
 

--- a/pkg/storage/oss.go
+++ b/pkg/storage/oss.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/vesoft-inc/nebula-br/pkg/context"
 	"go.uber.org/zap"
 )
 
@@ -19,7 +20,7 @@ type OSSBackedStore struct {
 	args          string
 }
 
-func NewOSSBackendStore(url string, log *zap.Logger, maxConcurrent int, args string) *OSSBackedStore {
+func NewOSSBackendStore(url string, log *zap.Logger, maxConcurrent int, args string, ctx *context.Context) *OSSBackedStore {
 	return &OSSBackedStore{url: url, log: log, maxConcurrent: strconv.Itoa(maxConcurrent), args: args}
 }
 
@@ -50,6 +51,9 @@ func (s OSSBackedStore) BackupMetaCommand(src []string) string {
 	return "ossutil cp -r " + filepath.Dir(src[0]) + " " + metaDir + " " + s.args + " -j " + s.maxConcurrent
 }
 
+func (s OSSBackedStore) BackupMetaDir() string {
+	return s.url + "/" + "meta"
+}
 func (s OSSBackedStore) BackupMetaFileCommand(src string) []string {
 	if len(s.args) == 0 {
 		return []string{"ossutil", "cp", "-r", src, s.url + "/", "-j", s.maxConcurrent}
@@ -99,6 +103,10 @@ func (s OSSBackedStore) RestoreStoragePreCommand(dst string) string {
 }
 func (s OSSBackedStore) URI() string {
 	return s.url
+}
+
+func (s OSSBackedStore) Scheme() string {
+	return SCHEME_OSS
 }
 
 func (s OSSBackedStore) CheckCommand() string {

--- a/pkg/storage/oss.go
+++ b/pkg/storage/oss.go
@@ -145,8 +145,10 @@ func (s OSSBackedStore) ListBackupCommand() ([]string, error) {
 		if index == -1 {
 			return nil, fmt.Errorf("Wrong oss file name %s", line)
 		}
-
-		dirs = append(dirs, strings.TrimRight(line[len(s.url):], "/"))
+		dentry := strings.TrimRight(line[len(s.url):], "/")
+		if dentry != "" {
+			dirs = append(dirs, dentry)
+		}
 	}
 	return dirs, nil
 }

--- a/pkg/storage/oss.go
+++ b/pkg/storage/oss.go
@@ -95,12 +95,22 @@ func (s OSSBackedStore) RestoreStorageCommand(host string, spaceID []string, dst
 	return cmd
 }
 
-func (s OSSBackedStore) RestoreMetaPreCommand(dst string) string {
-	return "rm -rf " + dst + " && mkdir -p " + dst
+func (s OSSBackedStore) RestoreMetaPreCommand(srcDir string, bkDir string) string {
+	return mvAndMkDirCommand(srcDir, bkDir)
 }
-func (s OSSBackedStore) RestoreStoragePreCommand(dst string) string {
-	return "rm -rf " + dst + " && mkdir -p " + dst
+
+func (s OSSBackedStore) RestoreStoragePreCommand(srcDir string, bkDir string) string {
+	return mvAndMkDirCommand(srcDir, bkDir)
 }
+
+func (s OSSBackedStore) RestoreMetaPostCommand(bkDir string) string {
+	return rmDirCommand(bkDir)
+}
+
+func (s OSSBackedStore) RestoreStoragePostCommand(bkDir string) string {
+	return rmDirCommand(bkDir)
+}
+
 func (s OSSBackedStore) URI() string {
 	return s.url
 }

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -95,12 +95,23 @@ func (s S3BackedStore) RestoreStorageCommand(host string, spaceID []string, dst 
 
 	return cmd
 }
-func (s S3BackedStore) RestoreMetaPreCommand(dst string) string {
-	return "rm -rf " + dst + " && mkdir -p " + dst
+
+func (s S3BackedStore) RestoreMetaPreCommand(srcDir string, bkDir string) string {
+	return mvAndMkDirCommand(srcDir, bkDir)
 }
-func (s S3BackedStore) RestoreStoragePreCommand(dst string) string {
-	return "rm -rf " + dst + " && mkdir -p " + dst
+
+func (s S3BackedStore) RestoreStoragePreCommand(srcDir string, bkDir string) string {
+	return mvAndMkDirCommand(srcDir, bkDir)
 }
+
+func (s S3BackedStore) RestoreMetaPostCommand(bkDir string) string {
+	return rmDirCommand(bkDir)
+}
+
+func (s S3BackedStore) RestoreStoragePostCommand(bkDir string) string {
+	return rmDirCommand(bkDir)
+}
+
 func (s S3BackedStore) URI() string {
 	return s.url
 }

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/vesoft-inc/nebula-br/pkg/context"
 	"go.uber.org/zap"
 )
 
@@ -19,7 +20,7 @@ type S3BackedStore struct {
 	command    string
 }
 
-func NewS3BackendStore(url string, log *zap.Logger, maxConcurrent int, args string) *S3BackedStore {
+func NewS3BackendStore(url string, log *zap.Logger, maxConcurrent int, args string, ctx *context.Context) *S3BackedStore {
 	return &S3BackedStore{url: url, log: log, args: args}
 }
 
@@ -49,6 +50,10 @@ func (s *S3BackedStore) BackupStorageCommand(src []string, host string, spaceID 
 func (s S3BackedStore) BackupMetaCommand(src []string) string {
 	metaDir := s.url + "/" + "meta/"
 	return "aws " + s.args + " s3 sync " + filepath.Dir(src[0]) + " " + metaDir
+}
+
+func (s S3BackedStore) BackupMetaDir() string {
+	return s.url + "/" + "meta"
 }
 
 func (s S3BackedStore) BackupMetaFileCommand(src string) []string {
@@ -98,6 +103,9 @@ func (s S3BackedStore) RestoreStoragePreCommand(dst string) string {
 }
 func (s S3BackedStore) URI() string {
 	return s.url
+}
+func (s S3BackedStore) Scheme() string {
+	return SCHEME_S3
 }
 
 func (s S3BackedStore) CheckCommand() string {

--- a/pkg/storage/s3_test.go
+++ b/pkg/storage/s3_test.go
@@ -4,19 +4,20 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/vesoft-inc/nebula-br/pkg/context"
 	"go.uber.org/zap"
 )
 
 var logger, _ = zap.NewProduction()
 
 func TestS3SetBackupName(t *testing.T) {
-	s3 := NewS3BackendStore("s3://nebulabackup/", logger, 5, "--cli-read-timeout")
+	s3 := NewS3BackendStore("s3://nebulabackup/", logger, 5, "--cli-read-timeout", &context.Context{})
 	s3.SetBackupName("backupname1")
 	assert.Equal(t, s3.backupName, "backupname1")
 
 	assert.Equal(t, s3.URI(), "s3://nebulabackup/backupname1")
 
-	s3 = NewS3BackendStore("s3://nebulabackup", logger, 5, "")
+	s3 = NewS3BackendStore("s3://nebulabackup", logger, 5, "", &context.Context{})
 	s3.SetBackupName("backupname2")
 	assert.Equal(t, s3.backupName, "backupname2")
 
@@ -25,7 +26,7 @@ func TestS3SetBackupName(t *testing.T) {
 
 func TestS3StorageCommand(t *testing.T) {
 	backupRegion := "s3://nebulabackup/"
-	s3 := NewS3BackendStore(backupRegion, logger, 5, "--cli-read-timeout ")
+	s3 := NewS3BackendStore(backupRegion, logger, 5, "--cli-read-timeout ", &context.Context{})
 	s3.SetBackupName("backupname3")
 	host := "127.0.0.1"
 	spaceID := "1"
@@ -40,7 +41,7 @@ func TestS3StorageCommand(t *testing.T) {
 }
 
 func TestS3MetaCommand(t *testing.T) {
-	s3 := NewS3BackendStore("s3://nebulabackup", logger, 5, "")
+	s3 := NewS3BackendStore("s3://nebulabackup", logger, 5, "", &context.Context{})
 	s3.SetBackupName("backupmeta")
 	files := []string{"/data/a.sst", "/data/b.sst", "/data/c.sst"}
 	cmd := s3.BackupMetaCommand(files)
@@ -54,7 +55,7 @@ func TestS3MetaCommand(t *testing.T) {
 
 func TestS3BackupMetaFileCommand(t *testing.T) {
 	backupRegion := "s3://nebulabackupfile/"
-	s3 := NewS3BackendStore(backupRegion, logger, 5, "")
+	s3 := NewS3BackendStore(backupRegion, logger, 5, "", &context.Context{})
 	s3.SetBackupName("backupmetafile")
 	metaFile := "/home/nebula/backup.meta"
 	cmd := s3.BackupMetaFileCommand(metaFile)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -25,8 +25,13 @@ type ExternalStorage interface {
 	RestoreMetaFileCommand(file string, dst string) []string
 	RestoreMetaCommand(src []string, dst string) (string, []string)
 	RestoreStorageCommand(host string, spaceID []string, dst []string) []string
-	RestoreMetaPreCommand(dst string) string
-	RestoreStoragePreCommand(dst string) string
+
+	RestoreMetaPreCommand(srcDir string, bkDir string) string
+	RestoreStoragePreCommand(srcDir string, bkDir string) string
+
+	RestoreMetaPostCommand(bkDir string) string
+	RestoreStoragePostCommand(bkDir string) string
+
 	CheckCommand() string
 	ListBackupCommand() ([]string, error)
 	URI() string

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -4,13 +4,22 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/vesoft-inc/nebula-br/pkg/context"
 	"go.uber.org/zap"
+)
+
+const (
+	SCHEME_HDFS  = "hdfs"
+	SCHEME_OSS   = "oss"
+	SCHEME_S3    = "s3"
+	SCHEME_LOCAL = "local"
 )
 
 type ExternalStorage interface {
 	SetBackupName(name string)
 	BackupPreCommand() []string
 	BackupStorageCommand(src []string, host string, spaceID string) []string
+	BackupMetaDir() string
 	BackupMetaCommand(src []string) string
 	BackupMetaFileCommand(src string) []string
 	RestoreMetaFileCommand(file string, dst string) []string
@@ -21,9 +30,10 @@ type ExternalStorage interface {
 	CheckCommand() string
 	ListBackupCommand() ([]string, error)
 	URI() string
+	Scheme() string
 }
 
-func NewExternalStorage(storageUrl string, log *zap.Logger, maxConcurrent int, args string) (ExternalStorage, error) {
+func NewExternalStorage(storageUrl string, log *zap.Logger, maxConcurrent int, args string, ctx *context.Context) (ExternalStorage, error) {
 	u, err := url.Parse(storageUrl)
 	if err != nil {
 		return nil, err
@@ -32,14 +42,14 @@ func NewExternalStorage(storageUrl string, log *zap.Logger, maxConcurrent int, a
 	log.Info("parsed external storage", zap.String("schema", u.Scheme), zap.String("path", u.Path))
 
 	switch u.Scheme {
-	case "local":
-		return NewLocalBackedStore(u.Path, log, maxConcurrent, args), nil
-	case "s3":
-		return NewS3BackendStore(storageUrl, log, maxConcurrent, args), nil
-	case "oss":
-		return NewOSSBackendStore(storageUrl, log, maxConcurrent, args), nil
-	case "hdfs":
-		return NewHDFSBackendStore(storageUrl, log, maxConcurrent, args), nil
+	case SCHEME_LOCAL:
+		return NewLocalBackedStore(u.Path, log, maxConcurrent, args, ctx), nil
+	case SCHEME_S3:
+		return NewS3BackendStore(storageUrl, log, maxConcurrent, args, ctx), nil
+	case SCHEME_OSS:
+		return NewOSSBackendStore(storageUrl, log, maxConcurrent, args, ctx), nil
+	case SCHEME_HDFS:
+		return NewHDFSBackendStore(storageUrl, log, maxConcurrent, args, ctx), nil
 	default:
 		return nil, fmt.Errorf("Unsupported Backend Storage Types")
 	}

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -85,3 +85,20 @@ func TestStorageCmdEmpty(t *testing.T) {
 	k1 := mkDirCommand("")
 	ast.Equal(k1, "")
 }
+
+func TestRmCmdCheck(t *testing.T) {
+	ast := assert.New(t)
+	invalidDsts := []string{
+		"/", "/abc/test /", "/data", "/some/sample/path_old_12345 ////",
+	}
+	for _, i := range invalidDsts {
+		res := sanityCheckForRM(i)
+		t.Logf("check '%s' ==> %v", i, res)
+		ast.False(res)
+	}
+
+	validDst := getBackDir("/some/data/path")
+	res := sanityCheckForRM(validDst)
+	t.Logf("check '%s' ==> %v", validDst, res)
+	ast.True(res)
+}

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -5,23 +5,24 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/vesoft-inc/nebula-br/pkg/context"
 	"go.uber.org/zap"
 )
 
 func TestStorage(t *testing.T) {
 	assert := assert.New(t)
 	logger, _ := zap.NewProduction()
-	s, err := NewExternalStorage("local:///tmp/backup", logger, 5, "")
+	s, err := NewExternalStorage("local:///tmp/backup", logger, 5, "", &context.Context{})
 	assert.NoError(err)
 	assert.Equal(reflect.TypeOf(s).String(), "*storage.LocalBackedStore")
 
 	assert.Equal(s.URI(), "/tmp/backup")
 
-	s, err = NewExternalStorage("s3://nebulabackup/", logger, 5, "")
+	s, err = NewExternalStorage("s3://nebulabackup/", logger, 5, "", &context.Context{})
 	assert.NoError(err)
 
 	assert.Equal(s.URI(), "s3://nebulabackup/")
 
-	s, err = NewExternalStorage("oss://nebulabackup/", logger, 5, "")
+	s, err = NewExternalStorage("oss://nebulabackup/", logger, 5, "", &context.Context{})
 	assert.NoError(err)
 }

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -1,11 +1,16 @@
 package storage
 
 import (
+	"flag"
+	"io/ioutil"
+	"os"
+	"os/exec"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/vesoft-inc/nebula-br/pkg/context"
+	"github.com/vesoft-inc/nebula-br/pkg/remote"
 	"go.uber.org/zap"
 )
 
@@ -25,4 +30,58 @@ func TestStorage(t *testing.T) {
 
 	s, err = NewExternalStorage("oss://nebulabackup/", logger, 5, "", &context.Context{})
 	assert.NoError(err)
+}
+
+var userName = flag.String("user", "", "user for test")
+
+func TestStorageCmdMv(t *testing.T) {
+	ast := assert.New(t)
+	logger, _ := zap.NewProduction()
+	if *userName == "" {
+		t.Log("should provide username")
+		return
+	}
+	dir := "/tmp/testdir"
+
+	cmd := exec.Command("mkdir", "-p", dir)
+	err := cmd.Run()
+	var cli *remote.Client
+
+	ast.Nil(err)
+
+	tname := "test.txt"
+	tcontent := "some.sample.content"
+
+	file, _ := os.OpenFile(dir+"/"+tname, os.O_RDWR|os.O_CREATE, 0755)
+	file.WriteString(tcontent)
+	file.Close()
+
+	bakpath := getBackDir(dir)
+	t.Logf("dir: %s , bakpath: %s", dir, bakpath)
+
+	cli, err = remote.NewClient("127.0.0.1", *userName, logger)
+	ast.Nil(err)
+
+	mvCmd := mvDirCommand(dir, bakpath)
+	err = cli.ExecCommandBySSH(mvCmd)
+	ast.Nil(err)
+
+	dat, _ := ioutil.ReadFile(bakpath + "/" + tname)
+	ast.Equal(string(dat), tcontent)
+}
+
+func TestStorageCmdEmpty(t *testing.T) {
+	ast := assert.New(t)
+	m1 := mvDirCommand("", "t")
+	m2 := mvDirCommand("t", "")
+	m3 := mvDirCommand("", "")
+	ast.Equal(m1, "")
+	ast.Equal(m2, "")
+	ast.Equal(m3, "")
+
+	r1 := rmDirCommand("")
+	ast.Equal(r1, "")
+
+	k1 := mkDirCommand("")
+	ast.Equal(k1, "")
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"flag"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vesoft-inc/nebula-br/pkg/metaclient"
+	"go.uber.org/zap"
+)
+
+var metafile = flag.String("meta", "", "metafile for test")
+
+func TestIterateMetaBackup(t *testing.T) {
+	ast := assert.New(t)
+	metafname := *metafile
+	logger, _ := zap.NewProduction()
+	if metafname == "" {
+		t.Log("meta should be provided!")
+		return
+	}
+
+	m, err := GetMetaFromFile(logger, metafname)
+	ast.Nil(err)
+
+	IterateBackupMeta(m.GetBackupInfo(), ShowBackupMeta{})
+
+	fmt.Printf("%s\n", metaclient.BackupMetaToString(m))
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,10 @@
+package version
+
+var (
+	VerMajor = 0
+	VerMinor = 1
+	VerPatch = 0
+	VerName  = "Nebula Backup And Restore Ultility Tool"
+	GitSha   = "UNKNOWN"
+	GitRef   = "UNKNOWN"
+)


### PR DESCRIPTION
this pr includes:
- meta backup and restore process of local storage refinement: fix restore failed for multiple meta service in local storage.
- add an option of backup command to show more information: now we can run with `--verbose` to show backup  information.
- add some unit tests